### PR TITLE
[1.8.9] Automagically set mod version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ minecraft {
     version = "1.8.9-11.15.0.1684"
     runDir = "eclipse"
     mappings = "snapshot_20151211"
+    replace "@VERSION@", project.version
+    replaceIn "FlatColoredBlocks.java"
 }
 
 processResources

--- a/src/main/java/mod/flatcoloredblocks/FlatColoredBlocks.java
+++ b/src/main/java/mod/flatcoloredblocks/FlatColoredBlocks.java
@@ -44,7 +44,7 @@ public class FlatColoredBlocks
 
 	public static final String MODNAME = "FlatColoredBlocks";
 	public static final String MODID = "flatcoloredblocks";
-	public static final String VERSION = "mc1.8.9-v1.3";
+	public static final String VERSION = "@VERSION@";
 
 	public static final String DEPENDENCIES = "required-after:Forge@[" // forge.
 			+ net.minecraftforge.common.ForgeVersion.majorVersion + '.' // majorVersion


### PR DESCRIPTION
A tiny change to let gradle set mod version in .java file to help mods like Version Checker not be confused.
